### PR TITLE
Referral partners

### DIFF
--- a/db/migrate/20180912223800_add_referrer_to_users.rb
+++ b/db/migrate/20180912223800_add_referrer_to_users.rb
@@ -1,0 +1,5 @@
+class AddReferrerToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :referrer, :string
+  end
+end

--- a/lib/pr/common.rb
+++ b/lib/pr/common.rb
@@ -4,6 +4,7 @@ require 'pr/common/configuration'
 require 'pr/common/tokenable'
 require 'pr/common/shopifyable'
 require 'pr/common/token_authenticable'
+require 'pr/common/affiliate_redirect'
 
 module PR
   module Common

--- a/lib/pr/common.rb
+++ b/lib/pr/common.rb
@@ -5,6 +5,7 @@ require 'pr/common/tokenable'
 require 'pr/common/shopifyable'
 require 'pr/common/token_authenticable'
 require 'pr/common/affiliate_redirect'
+require 'pr/common/models/user'
 
 module PR
   module Common

--- a/lib/pr/common/affiliate_redirect.rb
+++ b/lib/pr/common/affiliate_redirect.rb
@@ -1,0 +1,19 @@
+module PR
+  module Common
+    class AffiliateRedirect
+      def initialize(app)
+        @app = app
+      end
+      def call(env)
+        req = Rack::Request.new(env)
+        status, headers, body = @app.call(env)
+
+        if req.env['rack.request.query_hash']['ref'] && PR::Common.config.referrer_redirect
+          return [302, {'Location' => PR::Common.config.referrer_redirect, 'Content-Type' => 'text/html'}, ['Found']]
+        end
+
+        [status, headers, body]
+      end
+    end
+  end
+end

--- a/lib/pr/common/configuration.rb
+++ b/lib/pr/common/configuration.rb
@@ -1,7 +1,7 @@
 module PR
   module Common
     class Configuration
-      attr_accessor :signup_params, :send_welcome_email, :send_confirmation_email
+      attr_accessor :signup_params, :send_welcome_email, :send_confirmation_email, :referrer_redirect
     end
   end
 end

--- a/lib/pr/common/engine.rb
+++ b/lib/pr/common/engine.rb
@@ -1,3 +1,4 @@
+require 'rack-affiliates'
 module PR
   module Common
     class Engine < ::Rails::Engine
@@ -11,6 +12,10 @@ module PR
             app.config.paths["db/migrate"] << expanded_path
           end
         end
+      end
+      initializer :enable_affiliates do |app|
+        app.middleware.use Rack::Affiliates
+        app.middleware.use PR::Common::AffiliateRedirect
       end
     end
   end

--- a/lib/pr/common/engine.rb
+++ b/lib/pr/common/engine.rb
@@ -1,10 +1,16 @@
 module PR
   module Common
     class Engine < ::Rails::Engine
-
       config.generators do |g|
         g.test_framework :rspec
         g.fixture_replacement :factory_bot, dir: 'spec/factories'
+      end
+      initializer :append_migrations do |app|
+        unless app.root.to_s.match root.to_s
+          config.paths["db/migrate"].expanded.each do |expanded_path|
+            app.config.paths["db/migrate"] << expanded_path
+          end
+        end
       end
     end
   end

--- a/lib/pr/common/models/user.rb
+++ b/lib/pr/common/models/user.rb
@@ -1,0 +1,16 @@
+module PR
+  module Common
+    module Models
+      # This is a stake in the ground to gradually improve our messy User code
+      # As much as possible should be in Common
+      # We will work towards this by including this module in our apps and moving generic pieces here
+      # So please include PR::Common::Models::User
+      module User
+        def self.included(base)
+
+        end
+      end
+    end
+  end
+end
+

--- a/pr-common.gemspec
+++ b/pr-common.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'active_model_serializers'
   s.add_dependency 'nokogiri', '>= 1.8.2'
   s.add_dependency 'activeresource'
+  s.add_dependency 'rack-affiliates'
 
   s.add_development_dependency 'rspec-rails'
 end


### PR DESCRIPTION
Cleaner solution than using the React app. Apart from the User which is messy, this is all self contained in Common. The param ref= stores in the cookie and redirects.

Then when the user signs up it is saved to the referrer column.

For common models we should start storing them in common. Added a mod to allow migrations to live in common.