### PR TITLE
Add version to migrations, plan_name check

### DIFF
--- a/db/migrate/20180912223800_add_referrer_to_users.rb
+++ b/db/migrate/20180912223800_add_referrer_to_users.rb
@@ -1,4 +1,4 @@
-class AddReferrerToUsers < ActiveRecord::Migration
+class AddReferrerToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :referrer, :string
   end

--- a/db/migrate/20180915214900_add_plan_name_to_shops.rb
+++ b/db/migrate/20180915214900_add_plan_name_to_shops.rb
@@ -1,5 +1,9 @@
-class AddPlanNameToShops < ActiveRecord::Migration
+class AddPlanNameToShops < ActiveRecord::Migration[5.0]
   def change
+    # prevent this migration failing for apps that already have a
+    # plan_name on shops
+    return if column_exists? :shops, :plan_name
+
     add_column :shops, :plan_name, :string
   end
 end

--- a/db/migrate/20180920132700_add_uninstalled_to_shops.rb
+++ b/db/migrate/20180920132700_add_uninstalled_to_shops.rb
@@ -1,4 +1,4 @@
-class AddUninstalledToShops < ActiveRecord::Migration
+class AddUninstalledToShops < ActiveRecord::Migration[5.0]
   def change
     add_column :shops, :uninstalled, :boolean, null: false, default: false
   end

--- a/db/migrate/20180922164900_drop_application_charges.rb
+++ b/db/migrate/20180922164900_drop_application_charges.rb
@@ -1,4 +1,4 @@
-class DropApplicationCharges < ActiveRecord::Migration
+class DropApplicationCharges < ActiveRecord::Migration[5.0]
   def change
     drop_table :application_charges
   end


### PR DESCRIPTION
These changes were required to update Plug in Backup.

1. Extending from ActiveRecord::Migration is not allowed without a version number now. This completely blows up.

```
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class AddReferrerToUsers < ActiveRecord::Migration[4.2]
```

2. `plan_name` already exists on shops in this app, so I needed to conditionally check that in the migration.