### PR TITLE
around_filter -> around_action

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -2,7 +2,7 @@ class ChargesController < ApplicationController
   include ShopifyApp::LoginProtection
 
   before_action :login_again_if_different_shop
-  around_filter :shopify_session
+  around_action :shopify_session
   before_action :find_user, :load_charge
 
   def create


### PR DESCRIPTION
`around_filter` is completely removed in Rails 5.1. This has been deprecated for some time, but now it blows things up when trying to use common inside a Rails 5.1 app.