### PR TITLE
Update migrations from 5.2 to 5.0

### DIFF
--- a/db/migrate/20181008114742_make_plan_name_not_nullable.rb
+++ b/db/migrate/20181008114742_make_plan_name_not_nullable.rb
@@ -1,4 +1,4 @@
-class MakePlanNameNotNullable < ActiveRecord::Migration[5.2]
+class MakePlanNameNotNullable < ActiveRecord::Migration[5.0]
   def change
     change_column_null :shops, :plan_name, false
   end

--- a/db/migrate/20181008151650_add_provider_to_users.rb
+++ b/db/migrate/20181008151650_add_provider_to_users.rb
@@ -1,4 +1,4 @@
-class AddProviderToUsers < ActiveRecord::Migration[5.2]
+class AddProviderToUsers < ActiveRecord::Migration[5.0]
   def change
     return if column_exists? :users, :provider
 


### PR DESCRIPTION
Plug in SEO can't migrate because of this: It doesn't expect anything above 5.0.

I think this is a reasonable fix.