### PR TITLE
Make plan nullable again (fixes initial shop creation)

### DIFF
--- a/db/migrate/20181009084529_make_plan_name_nullable.rb
+++ b/db/migrate/20181009084529_make_plan_name_nullable.rb
@@ -1,0 +1,5 @@
+class MakePlanNameNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :shops, :plan_name, true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_08_151650) do
+ActiveRecord::Schema.define(version: 2018_10_09_084529) do
 
   create_table "shops", force: :cascade do |t|
-    t.string "plan_name", null: false
+    t.string "plan_name"
     t.string "shopify_domain"
     t.string "shopify_token", null: false
     t.boolean "uninstalled", default: false, null: false


### PR DESCRIPTION
Creating shop on initial login fails with the previous constraint.