### PR TITLE
Switch latest migration to 5.0

### DIFF
--- a/db/migrate/20181009084529_make_plan_name_nullable.rb
+++ b/db/migrate/20181009084529_make_plan_name_nullable.rb
@@ -1,4 +1,4 @@
-class MakePlanNameNullable < ActiveRecord::Migration[5.2]
+class MakePlanNameNullable < ActiveRecord::Migration[5.0]
   def change
     change_column_null :shops, :plan_name, true
   end


### PR DESCRIPTION
Same as last time. Automatically generates a 5.2 but we need a 5.0