### PR TITLE
Make migrations more robust with checks to prevent failure

### DIFF
--- a/db/migrate/20180912223800_add_referrer_to_users.rb
+++ b/db/migrate/20180912223800_add_referrer_to_users.rb
@@ -1,5 +1,9 @@
 class AddReferrerToUsers < ActiveRecord::Migration[5.0]
   def change
+    # prevent this migration failing for apps that already have a
+    # referrer on users
+    return if column_exists? :users, :referrer
+
     add_column :users, :referrer, :string
   end
 end

--- a/db/migrate/20180920132700_add_uninstalled_to_shops.rb
+++ b/db/migrate/20180920132700_add_uninstalled_to_shops.rb
@@ -1,5 +1,9 @@
 class AddUninstalledToShops < ActiveRecord::Migration[5.0]
   def change
+    # prevent this migration failing for apps that already have an
+    # uninstalled on shops
+    return if column_exists? :shops, :uninstalled
+
     add_column :shops, :uninstalled, :boolean, null: false, default: false
   end
 end

--- a/db/migrate/20181008151650_add_provider_to_users.rb
+++ b/db/migrate/20181008151650_add_provider_to_users.rb
@@ -1,5 +1,7 @@
 class AddProviderToUsers < ActiveRecord::Migration[5.0]
   def change
+    # prevent this migration failing for apps that already have a
+    # provider on users
     return if column_exists? :users, :provider
 
     add_column :users, :provider, :integer


### PR DESCRIPTION
Fresh DB migration can fail if we don't add these checks.