### PR TITLE
Add webhook recreation rake task

### DIFF
--- a/lib/pr/common.rb
+++ b/lib/pr/common.rb
@@ -8,6 +8,7 @@ require 'pr/common/models/user'
 require 'pr/common/models/shop'
 require 'pr/common/user_service'
 require 'pr/common/shopify_service'
+require 'pr/common/webhook_service'
 
 module PR
   module Common

--- a/lib/pr/common/webhook_service.rb
+++ b/lib/pr/common/webhook_service.rb
@@ -1,0 +1,68 @@
+module PR
+  module Common
+    class WebhookService
+      def initialize(shop)
+        @shop = shop
+      end
+
+      def recreate_webhooks!
+        wrap_errors do
+          with_shop do
+            Rails.logger.info "Recreating webhooks for #{@shop.shopify_domain}"
+
+            # If anything fails due to shop not being installed,
+            # I would expect it to happen here.
+            existing_webhooks = fetch_existing
+
+            # ensure that any new webhooks are installed first.
+            # that way, if something goes wrong, at least we haven't removed
+            # anything.
+            install_from_config
+
+            destroy(existing_webhooks)
+          end
+        end
+      end
+
+      private
+
+      def fetch_existing
+        ShopifyAPI::Webhook.all
+      end
+
+      def install_from_config
+        ShopifyApp.configuration.webhooks.each(&(ShopifyAPI::Webhook.method(:create)))
+      end
+
+      def destroy(webhooks)
+        Array.wrap(webhooks).each { |webhook| ShopifyAPI::Webhook.delete(webhook.id) }
+      end
+
+      def with_shop
+        ShopifyAPI::Session.temp(@shop.shopify_domain, @shop.shopify_token) do
+          return yield
+        end
+      end
+
+      # We don't want things to explode if something goes wrong, but we do want to
+      # notify.
+      def wrap_errors
+        yield
+      rescue ActiveResource::ConnectionError => e
+        # When a connection fails in some way, assume the shop was uninstalled.
+        Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
+          "Consider checking if it's still installed, and uninstalling if not. Error: "\
+          "#{e.message}"
+      rescue Timeout::Error => e
+        Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
+          "Connection timed out. Error: #{e.message}"
+      rescue OpenSSL::SSL::SSLError => e
+        Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
+          "SSLError. Error: #{e.message}"
+      rescue Exception => e
+        Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
+          "This shouldn't have happened. Error: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/pr/common/webhook_service.rb
+++ b/lib/pr/common/webhook_service.rb
@@ -5,7 +5,7 @@ module PR
       def self.recreate_webhooks!(shops = Shop.installed)
         shops.find_each.map do |shop|
           new(shop).recreate_webhooks! || shop.shopify_domain
-        end.compact
+        end.reject { |item| item == true }
       end
 
       def initialize(shop)
@@ -27,6 +27,8 @@ module PR
             install_from_config
 
             destroy(existing_webhooks)
+
+            true
           end
         end
       end
@@ -61,28 +63,28 @@ module PR
           "Unauthorized: Consider checking if it's still installed, and uninstalling if not. Error: "\
           "#{e.message}"
 
-        false
+        return false
       rescue ActiveResource::ConnectionError => e
         Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
           "Some kind of connection error occurred. Error: "\
           "#{e.message}"
 
-        false
+        return false
       rescue Timeout::Error => e
         Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
           "Connection timed out. Error: #{e.message}"
 
-        false
+        return false
       rescue OpenSSL::SSL::SSLError => e
         Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
           "SSLError. Error: #{e.message}"
 
-        false
+        return false
       rescue Exception => e
         Rails.logger.error "Failed to modify webhooks for #{@shop.shopify_domain}. "\
           "This shouldn't have happened. Error: #{e.message}"
 
-        false
+        return false
       end
     end
   end

--- a/lib/tasks/pr/common_tasks.rake
+++ b/lib/tasks/pr/common_tasks.rake
@@ -6,7 +6,10 @@ namespace 'common' do
       Rails.logger = Logger.new Rails.root.join('tmp', 'common-webhooks-recreate.log')
 
       shops = if args[:shops_file].present?
-                Shop.where(shopify_domain: File.read(args[:shops_file]).map(&:strip))
+                Shop.where( shopify_domain: File
+                                            .read(args[:shops_file])
+                                            .split('\s')
+                                            .map(&:strip))
               else
                 Shop.installed
               end

--- a/lib/tasks/pr/common_tasks.rake
+++ b/lib/tasks/pr/common_tasks.rake
@@ -1,14 +1,17 @@
 namespace 'common' do
   namespace 'webhooks' do
     desc "Recreate all webhooks based on config. Optionally pass a comma-separated list of domains."
-    task :recreate, [:shops] => [:environment] do
-      shops = args[:shops].blank? &&
-              Shop.all ||
-              Shop.where(shopify_domain: args[:shops].split(',').map(&:strip))
+    task :recreate, [:shops_file] => [:environment] do |_, args|
+      FileUtils.mkdir_p(Rails.root.join('tmp'))
+      Rails.logger = Logger.new Rails.root.join('tmp', 'common-webhooks-recreate.log')
 
-      shops.each do |shop|
-        PR::Common::WebhookService.new(shop).recreate_webhooks!
-      end
+      shops = if args[:shops_file].present?
+                Shop.where(shopify_domain: File.read(args[:shops_file]).map(&:strip))
+              else
+                Shop.installed
+              end
+
+      puts PR::Common::WebhookService.recreate_webhooks!(shops)
     end
   end
 end

--- a/lib/tasks/pr/common_tasks.rake
+++ b/lib/tasks/pr/common_tasks.rake
@@ -1,4 +1,14 @@
-# desc "Explaining what the task does"
-# task :pr_common do
-#   # Task goes here
-# end
+namespace 'common' do
+  namespace 'webhooks' do
+    desc "Recreate all webhooks based on config. Optionally pass a comma-separated list of domains."
+    task :recreate, [:shops] => [:environment] do
+      shops = args[:shops].blank? &&
+              Shop.all ||
+              Shop.where(shopify_domain: args[:shops].split(',').map(&:strip))
+
+      shops.each do |shop|
+        PR::Common::WebhookService.new(shop).recreate_webhooks!
+      end
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_09_084529) do
+ActiveRecord::Schema.define(version: 2018_10_09_124306) do
 
   create_table "shops", force: :cascade do |t|
-    t.string "plan_name", null: false
+    t.string "plan_name"
     t.string "shopify_domain"
     t.string "shopify_token", null: false
     t.boolean "uninstalled", default: false, null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_084529) do
     t.integer "shop_id"
     t.string "referrer"
     t.integer "provider"
+    t.datetime "charged_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2018_10_09_084529) do
 
   create_table "shops", force: :cascade do |t|
-    t.string "plan_name"
+    t.string "plan_name", null: false
     t.string "shopify_domain"
     t.string "shopify_token", null: false
     t.boolean "uninstalled", default: false, null: false

--- a/spec/factories/shops.rb
+++ b/spec/factories/shops.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     sequence(:shopify_domain) { |n| "shop#{n}" }
     shopify_token { "MyString" }
     plan_name { 'affiliate' }
+    uninstalled { false }
+
+    trait :uninstalled do
+      uninstalled { true }
+    end
   end
 end

--- a/spec/lib/pr/common/webhook_service_spec.rb
+++ b/spec/lib/pr/common/webhook_service_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe PR::Common::WebhookService do
+  let(:shop) { create(:shop) }
+  let(:existing_webhooks) do
+    [
+      OpenStruct.new(
+        id: 1,
+        address: 'https://localhost:3000/webhooks/shop_update',
+        topic: 'shop/update',
+        created_at: "2018-10-09T08:08:15-04:00",
+        updated_at: "2018-10-09T08:08:15-04:00",
+        format: 'json',
+        fields: [],
+        metafield_namespaces: []
+      )
+    ]
+  end
+  let(:new_webhooks) do
+    [{
+      topic: "app/uninstalled",
+      address: "https://localhost:3000/webhooks/app_uninstalled",
+      format: 'json'
+    }]
+  end
+
+  subject(:service) { described_class.new(shop) }
+
+  describe '#recreate_webhooks!' do
+    before do
+      allow(ShopifyApp.configuration).to receive(:webhooks) { new_webhooks }
+      allow(ShopifyAPI::Webhook).to receive(:all) { existing_webhooks }
+      allow(ShopifyAPI::Webhook).to receive(:delete).with(existing_webhooks.first)
+      allow(ShopifyAPI::Webhook).to receive(:create).with(new_webhooks.first)
+    end
+
+    it 'requests all existing webhooks' do
+      expect(ShopifyAPI::Webhook).to receive(:all)
+
+      service.recreate_webhooks!
+    end
+
+    it 'creates new webhooks' do
+      expect(ShopifyAPI::Webhook).to receive(:create).with(new_webhooks.first)
+
+      service.recreate_webhooks!
+    end
+
+    it 'deletes existing webhooks' do
+      expect(ShopifyAPI::Webhook).to receive(:delete).with(existing_webhooks.first.id)
+
+      service.recreate_webhooks!
+    end
+  end
+end
+


### PR DESCRIPTION
Schema is included because tests required a migration to be run.

I believe this job will require us to take a good look at the resulting log and check that any failures are indeed from shops which have uninstalled the app. With that in mind, *all* new webhooks are created before any are deleted, so this *should* be safe.

Please merge this very carefully; it's important.

- Task can be run with `rake "common:webhooks:recreate"`. By default this only runs through shops that are installed.
- Output of the task (STDOUT) ONLY lists shopify domains that failed for some reason, so we can put these in a file for later use
- Log (in tmp/) contains information about every domain attempted, with various error logging.
- Task can also be run with a file containing the list of shopify domains (like the one it outputs): `rake "common:webhooks:recreate[filename]"`

I've personally confirmed the following with real test shops:

- it does not run through uninstalled apps
- only failed items show up in the output
- all items show in the output and errors are logged too.
- passing in `tmp/output.log` will only run through those items.
- it actually updates the webhooks correctly