### PR TITLE
Add backwards-compatible app-uninstalled webhook to `/webhooks/`

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,11 @@
+class WebhooksController < ShopifyApp::WebhooksController
+  def receive
+    # Backwards-compatible uninstalled webhook at /webhooks/.
+    # Can be removed later.
+    if webhook_type.blank? && request.headers['HTTP_X_SHOPIFY_TOPIC'] == 'app/uninstalled'
+        params[:type] = 'app_uninstalled'
+    end
+
+    super
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
   post 'shops/callback'
 
+  post 'webhooks', to: 'webhooks#receive'
+
   resources :charges,      only: [:create] do
     collection do
       get :callback


### PR DESCRIPTION
Tested this with POST `/webhooks` and POST `/webhooks/app_installed` with identical params. Works for both, as it should.