### PR TITLE
Remove migration that breaks app migration

### DIFF
--- a/db/migrate/20181008114742_make_plan_name_not_nullable.rb
+++ b/db/migrate/20181008114742_make_plan_name_not_nullable.rb
@@ -1,5 +1,0 @@
-class MakePlanNameNotNullable < ActiveRecord::Migration[5.0]
-  def change
-    change_column_null :shops, :plan_name, false
-  end
-end


### PR DESCRIPTION
Tested on NPS, works.

Problem was that we'd first add the field without a default, then say it can't be null. We later reverted this anyway.